### PR TITLE
Avoid recursion when checking graph search space.

### DIFF
--- a/src/pathfinding.rs
+++ b/src/pathfinding.rs
@@ -96,51 +96,42 @@ pub fn to_coord_map(
 }
 
 fn calculate(search: &mut Search, grid: &Grid) {
-  match search.size() {
-    0 => (),
-    _ => {
-      if search.reached_destination() {
-        ()
-      } else {
+    while search.size() != 0 && !search.reached_destination() {
         let mut node = search.pop().unwrap();
         node.visited = true;
         search.cache(node);
 
         // cardinal
         if grid.in_grid(node.x, node.y - 1) {
-          search.check_adjacent_node(grid, &node, 0, -1)
+            search.check_adjacent_node(grid, &node, 0, -1)
         }
         // hex & intercardinal
         if !grid.is_cardinal() & grid.in_grid(node.x + 1, node.y - 1) {
-          search.check_adjacent_node(grid, &node, 1, -1)
+            search.check_adjacent_node(grid, &node, 1, -1)
         }
         // cardinal
         if grid.in_grid(node.x + 1, node.y) {
-          search.check_adjacent_node(grid, &node, 1, 0)
+            search.check_adjacent_node(grid, &node, 1, 0)
         }
         // intercardinal
         if grid.is_intercardinal() & grid.in_grid(node.x + 1, node.y + 1) {
-          search.check_adjacent_node(grid, &node, 1, 1)
+            search.check_adjacent_node(grid, &node, 1, 1)
         }
         // cardinal
         if grid.in_grid(node.x, node.y + 1) {
-          search.check_adjacent_node(grid, &node, 0, 1)
+            search.check_adjacent_node(grid, &node, 0, 1)
         }
         // hex & intercardinal
         if !grid.is_cardinal() & grid.in_grid(node.x - 1, node.y + 1) {
-          search.check_adjacent_node(grid, &node, -1, 1)
+            search.check_adjacent_node(grid, &node, -1, 1)
         }
         // cardinal
         if grid.in_grid(node.x - 1, node.y) {
-          search.check_adjacent_node(grid, &node, -1, 0)
+            search.check_adjacent_node(grid, &node, -1, 0)
         }
         // intercardinal
         if grid.is_intercardinal() & grid.in_grid(node.x - 1, node.y - 1) {
-          search.check_adjacent_node(grid, &node, -1, -1)
+            search.check_adjacent_node(grid, &node, -1, -1)
         }
-
-        calculate(search, grid)
-      }
     }
-  }
 }

--- a/tests/find_path.rs
+++ b/tests/find_path.rs
@@ -12,6 +12,48 @@ macro_rules! hashmap {
 }
 
 #[test]
+fn gives_up() {
+  let grid = Grid {
+    tiles: vec![
+      vec![1, 1, 0, 1, 1, 1],
+      vec![1, 1, 0, 1, 0, 0],
+      vec![1, 1, 0, 0, 1, 1],
+      vec![1, 1, 1, 1, 1, 1],
+      vec![1, 1, 1, 1, 1, 1],
+      vec![1, 1, 1, 1, 1, 1],
+      vec![1, 1, 1, 1, 1, 1],
+      vec![1, 1, 1, 1, 1, 1],
+      vec![1, 1, 1, 1, 1, 1],
+      vec![1, 1, 1, 1, 1, 1],
+      vec![1, 1, 1, 1, 1, 1],
+      vec![1, 1, 1, 1, 1, 1],
+      vec![1, 1, 1, 1, 1, 1],
+      vec![1, 1, 1, 1, 1, 1],
+      vec![1, 1, 1, 1, 1, 1],
+      vec![1, 1, 1, 1, 1, 1],
+      vec![1, 1, 1, 1, 1, 1],
+      vec![1, 1, 1, 1, 1, 1],
+      vec![1, 1, 1, 1, 1, 1],
+      vec![1, 1, 1, 1, 1, 1],
+      vec![1, 1, 1, 1, 1, 1],
+      vec![1, 1, 1, 1, 1, 1],
+      vec![1, 1, 1, 1, 1, 1],
+    ],
+    walkable_tiles: vec![1],
+    ..Grid::default()
+  };
+  let start = Coord::new(1, 2);
+  let end = Coord::new(3, 1);
+  let opts = SearchOpts::default();
+  let path = find_path(&grid, start, end, opts);
+
+  assert_eq!(
+    path,
+    None,
+  );
+}
+
+#[test]
 fn traverses_walkable_tiles() {
   let grid = Grid {
     tiles: vec![


### PR DESCRIPTION
By using a loop instead of recursion we avoid the risk of stack overflow when the search space is too large. Fixes #1.